### PR TITLE
feat: accept endpoint and headers from mcp client

### DIFF
--- a/src/helpers/headers.ts
+++ b/src/helpers/headers.ts
@@ -1,0 +1,26 @@
+/**
+ * Parse and merge headers from various sources
+ * @param configHeaders - Default headers from configuration
+ * @param inputHeaders - Headers provided by the user (string or object)
+ * @returns Merged headers object
+ */
+export function parseAndMergeHeaders(
+  configHeaders: Record<string, string>,
+  inputHeaders?: string | Record<string, string>
+): Record<string, string> {
+  // Parse headers if they're provided as a string
+  let parsedHeaders: Record<string, string> = {};
+  
+  if (typeof inputHeaders === 'string') {
+    try {
+      parsedHeaders = JSON.parse(inputHeaders);
+    } catch (e) {
+      throw new Error(`Invalid headers JSON: ${e}`);
+    }
+  } else if (inputHeaders) {
+    parsedHeaders = inputHeaders;
+  }
+  
+  // Merge with config headers (config headers are overridden by input headers)
+  return { ...configHeaders, ...parsedHeaders };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
 	introspectLocalSchema,
 } from "./helpers/introspection.js";
 import { getVersion } from "./helpers/package.js" with { type: "macro" };
+import { parseAndMergeHeaders } from "./helpers/headers.js";
 
 const graphQLSchema = z.object({
 	query: z.string(),
@@ -113,14 +114,19 @@ server.resource(
 server.tool(
 	"introspect-schema",
 	"Introspect the GraphQL schema, use this tool before doing a query to get the schema information if you do not have it available as a resource already.",
-	{},
-	async () => {
+	{
+		endpoint: z.string().url().optional(),
+		headers: z.union([z.record(z.string()), z.string()]).optional(),
+	},
+	async ({ endpoint, headers }) => {
 		try {
 			let schema: string;
 			if (config.schema) {
 				schema = await introspectLocalSchema(config.schema);
 			} else {
-				schema = await introspectEndpoint(config.endpoint, config.headers);
+				const useEndpoint = endpoint || config.endpoint;
+				const useHeaders = parseAndMergeHeaders(config.headers, headers);
+				schema = await introspectEndpoint(useEndpoint, useHeaders);
 			}
 
 			return {
@@ -140,8 +146,13 @@ server.tool(
 server.tool(
 	"query-graphql",
 	"Query a GraphQL endpoint with the given query and variables",
-	{ query: z.string(), variables: z.string().optional() },
-	async ({ query, variables }) => {
+	{
+		query: z.string(),
+		variables: z.string().optional(),
+		endpoint: z.string().url().optional(),
+		headers: z.union([z.record(z.string()), z.string()]).optional(),
+	},
+	async ({ query, variables, endpoint, headers }) => {
 		try {
 			const parsedQuery = parse(query);
 
@@ -175,11 +186,14 @@ server.tool(
 		}
 
 		try {
-			const response = await fetch(config.endpoint, {
+			const useEndpoint = endpoint || config.endpoint;
+			const useHeaders = parseAndMergeHeaders(config.headers, headers);
+			
+			const response = await fetch(useEndpoint, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					...config.headers,
+					...useHeaders,
 				},
 				body: JSON.stringify({
 					query,

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,8 +115,10 @@ server.tool(
 	"introspect-schema",
 	"Introspect the GraphQL schema, use this tool before doing a query to get the schema information if you do not have it available as a resource already.",
 	{
-		endpoint: z.string().url().optional(),
-		headers: z.union([z.record(z.string()), z.string()]).optional(),
+		endpoint: z.string().url().optional()
+			.describe(`Optional: Override the default endpoint, the already used endpoint is: ${config.endpoint}`),
+		headers: z.union([z.record(z.string()), z.string()]).optional()
+			.describe(`Optional: Add additional headers, the already used headers are: ${JSON.stringify(config.headers)}`),
 	},
 	async ({ endpoint, headers }) => {
 		try {
@@ -149,8 +151,10 @@ server.tool(
 	{
 		query: z.string(),
 		variables: z.string().optional(),
-		endpoint: z.string().url().optional(),
-		headers: z.union([z.record(z.string()), z.string()]).optional(),
+		endpoint: z.string().url().optional()
+			.describe(`Optional: Override the default endpoint, the already used endpoint is: ${config.endpoint}`),
+		headers: z.union([z.record(z.string()), z.string()]).optional()
+			.describe(`Optional: Add additional headers, the already used headers are: ${JSON.stringify(config.headers)}`),
 	},
 	async ({ query, variables, endpoint, headers }) => {
 		try {


### PR DESCRIPTION
# Related Issues

https://github.com/blurrah/mcp-graphql/issues/6

# Summary

In this PR, I modify the mcp-graphql's mcp-server to allow receiving headers and endpoints from the mcp-client.
With this change, even if the MCP Client deploys the GraphQL server to some BaaS, it will be able to send requests without modifying the mcp-graphql configuration.