### PR TITLE
Fix: Properly handle schema option in parseArgs function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,8 +59,11 @@ function parseArgs(): Config {
 
 	try {
 		return ConfigSchema.parse({
+			name: argv.name,
 			endpoint: argv.endpoint,
+			allowMutations: argv["enable-mutations"],
 			headers: typeof argv.headers === "string" ? JSON.parse(argv.headers) : {},
+			schema: argv.schema
 		});
 	} catch (error) {
 		if (error instanceof z.ZodError) {


### PR DESCRIPTION
# Fix: Properly handle schema option in parseArgs function

## Problem
The `--schema` command line option isn't working properly because the `parseArgs` function doesn't include the schema path in the returned configuration object. This causes the application to always use introspection even when a local schema file is specified.

## Solution
Updated the `parseArgs` function to properly include all command line arguments in the configuration object, specifically:
- Added `name` from argv.name
- Added `allowMutations` from argv["enable-mutations"]
- Added `schema` from argv.schema

The code now correctly respects the `--schema` option as documented in the README.

## Testing
Tested locally by running the application with a local schema file:
node ./dist/index.js --endpoint http://localhost:3000/graphql --schema ./schema.graphql
Verified that the application now uses the local schema file rather than performing introspection.

## Additional Notes
This is a small but important fix that ensures the application behaves as documented in the README. No additional tests or documentation changes were needed as this functionality was already documented.