### PR TITLE
Parse ALLOW_MUTATIONS as string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ checkDeprecatedArguments();
 const EnvSchema = z.object({
 	NAME: z.string().default("mcp-graphql"),
 	ENDPOINT: z.string().url().default("http://localhost:4000/graphql"),
-	ALLOW_MUTATIONS: z.boolean().default(false),
+	ALLOW_MUTATIONS: z.enum(['true', 'false']).transform((value) => value === 'true').default("false"),
 	HEADERS: z
 		.string()
 		.default("{}")


### PR DESCRIPTION
Before:
```
$ ALLOW_MUTATIONS=true npx mcp-graphql
...
ZodError: [
  {
    "code": "invalid_type",
    "expected": "boolean",
    "received": "string",
    "path": [
      "ALLOW_MUTATIONS"
    ],
    "message": "Expected boolean, received string"
  }
]
```

After: Working as expected.

Snippet from https://github.com/colinhacks/zod/issues/2985#issuecomment-2023709169