### PR TITLE
Fix zod typing for variables definition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ server.tool(
 	"Query a GraphQL endpoint with the given query and variables",
 	{
 		query: z.string(),
-		variables: z.string().optional(),
+		variables: z.record(z.any()).optional(),
 	},
 	async ({ query, variables }) => {
 		try {


### PR DESCRIPTION
The "query-graphql" tool's variables zod definition currently tells the LLM that it expects a string, which the LLM interprets as needing to be a JSON string. This will cause requests to fail, and then the LLM needs to figure out how to fix, which it does some of the time. By properly changing this to a zod record object, it allows the LLM to format the variables correctly the first time.

This will fix issue https://github.com/blurrah/mcp-graphql/issues/26