### PR TITLE
feat: multi-endpoint, response offloading, schema summary, CSV export

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mcp-graphql",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+
+export const EndpointConfigSchema = z.object({
+	name: z.string(),
+	url: z.string().url(),
+	headers: z.record(z.string()).default({}),
+	allowMutations: z.boolean().default(false),
+	schema: z.string().optional(),
+});
+
+export type EndpointConfig = z.infer<typeof EndpointConfigSchema>;
+
+export const AppConfigSchema = z.object({
+	endpoints: z.array(EndpointConfigSchema).min(1),
+	responseSizeThreshold: z.number().int().positive().default(2048),
+	outputDir: z.string().default("/tmp/mcp-graphql/"),
+	defaultEndpoint: z.string().optional(),
+});
+
+export type AppConfig = z.infer<typeof AppConfigSchema>;
+
+/**
+ * Load configuration from either a JSON config file (MCP_GRAPHQL_CONFIG env var)
+ * or from legacy environment variables for backward compatibility.
+ */
+export function loadConfig(): AppConfig {
+	const configPath = process.env.MCP_GRAPHQL_CONFIG;
+
+	let config: AppConfig;
+
+	if (configPath) {
+		config = loadFromFile(configPath);
+	} else {
+		config = loadFromLegacyEnv();
+	}
+
+	// MCP_GRAPHQL_OUTPUT_DIR overrides config.outputDir
+	if (process.env.MCP_GRAPHQL_OUTPUT_DIR) {
+		config.outputDir = process.env.MCP_GRAPHQL_OUTPUT_DIR;
+	}
+
+	return config;
+}
+
+function loadFromFile(path: string): AppConfig {
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch (error) {
+		throw new Error(`Failed to read config file at ${path}: ${error}`);
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		throw new Error(`Failed to parse config file as JSON: ${error}`);
+	}
+
+	return AppConfigSchema.parse(parsed);
+}
+
+function loadFromLegacyEnv(): AppConfig {
+	const name = process.env.NAME ?? "default";
+	const url = process.env.ENDPOINT ?? "http://localhost:4000/graphql";
+	const allowMutations = process.env.ALLOW_MUTATIONS === "true";
+	const schema = process.env.SCHEMA;
+
+	// Validate URL
+	z.string().url().parse(url);
+
+	let headers: Record<string, string> = {};
+	if (process.env.HEADERS) {
+		try {
+			headers = JSON.parse(process.env.HEADERS);
+		} catch (e) {
+			throw new Error("HEADERS must be a valid JSON string");
+		}
+	}
+
+	const responseSizeThreshold = process.env.RESPONSE_SIZE_THRESHOLD
+		? Number.parseInt(process.env.RESPONSE_SIZE_THRESHOLD, 10)
+		: 2048;
+
+	if (Number.isNaN(responseSizeThreshold) || responseSizeThreshold <= 0) {
+		throw new Error("RESPONSE_SIZE_THRESHOLD must be a positive integer");
+	}
+
+	const outputDir =
+		process.env.MCP_GRAPHQL_OUTPUT_DIR ?? "/tmp/mcp-graphql/";
+
+	return {
+		endpoints: [
+			{
+				name,
+				url,
+				headers,
+				allowMutations,
+				schema,
+			},
+		],
+		responseSizeThreshold,
+		outputDir,
+		defaultEndpoint: name,
+	};
+}

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -1,0 +1,49 @@
+/**
+ * Escape a CSV cell value.
+ * Wraps in double quotes if the value contains a comma, double quote, or newline.
+ * Double quotes within the value are escaped as "".
+ */
+function escapeCsvCell(value: any): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const str = typeof value === "object" ? JSON.stringify(value) : String(value);
+
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Convert an array of objects to a CSV string.
+ *
+ * - Header row derived from keys of the first object.
+ * - Nested objects/arrays are serialized with JSON.stringify.
+ * - Values containing commas, quotes, or newlines are properly escaped.
+ *
+ * Returns null if data is not a non-empty array of objects.
+ */
+export function jsonToCsv(data: any[]): string | null {
+  if (!Array.isArray(data) || data.length === 0) {
+    return null;
+  }
+
+  const first = data[0];
+  if (first == null || typeof first !== "object" || Array.isArray(first)) {
+    return null;
+  }
+
+  const headers = Object.keys(first);
+  const lines: string[] = [];
+
+  lines.push(headers.map(escapeCsvCell).join(","));
+
+  for (const row of data) {
+    const cells = headers.map((h) => escapeCsvCell(row?.[h]));
+    lines.push(cells.join(","));
+  }
+
+  return lines.join("\n");
+}

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -1,0 +1,79 @@
+import type { AppConfig, EndpointConfig } from "./config.js";
+
+/**
+ * Registry for managing multiple GraphQL endpoints.
+ * Resolves endpoint names to their configurations.
+ */
+export class EndpointRegistry {
+	private readonly endpointsByName: Map<string, EndpointConfig>;
+	private readonly defaultName: string;
+
+	constructor(config: AppConfig) {
+		this.endpointsByName = new Map();
+
+		for (const endpoint of config.endpoints) {
+			if (this.endpointsByName.has(endpoint.name)) {
+				throw new Error(
+					`Duplicate endpoint name: "${endpoint.name}"`,
+				);
+			}
+			this.endpointsByName.set(endpoint.name, endpoint);
+		}
+
+		// Default endpoint: explicit config, or first endpoint
+		if (config.defaultEndpoint) {
+			if (!this.endpointsByName.has(config.defaultEndpoint)) {
+				throw new Error(
+					`Default endpoint "${config.defaultEndpoint}" not found in configured endpoints`,
+				);
+			}
+			this.defaultName = config.defaultEndpoint;
+		} else {
+			this.defaultName = config.endpoints[0].name;
+		}
+	}
+
+	/**
+	 * Resolve an endpoint by name. If no name is provided, returns the default endpoint.
+	 * Throws if the named endpoint is not found.
+	 */
+	resolve(name?: string): EndpointConfig {
+		if (!name) {
+			return this.getDefault();
+		}
+
+		const endpoint = this.endpointsByName.get(name);
+		if (!endpoint) {
+			const available = this.names().join(", ");
+			throw new Error(
+				`Endpoint "${name}" not found. Available endpoints: ${available}`,
+			);
+		}
+		return endpoint;
+	}
+
+	/**
+	 * Returns all configured endpoints.
+	 */
+	list(): EndpointConfig[] {
+		return Array.from(this.endpointsByName.values());
+	}
+
+	/**
+	 * Returns the default endpoint configuration.
+	 */
+	getDefault(): EndpointConfig {
+		const endpoint = this.endpointsByName.get(this.defaultName);
+		if (!endpoint) {
+			throw new Error("No default endpoint configured");
+		}
+		return endpoint;
+	}
+
+	/**
+	 * Returns all endpoint names.
+	 */
+	names(): string[] {
+		return Array.from(this.endpointsByName.keys());
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { parse } from "graphql/language";
 import { z } from "zod";
+import { loadConfig } from "./config.js";
 import { checkDeprecatedArguments } from "./helpers/deprecation.js";
 import {
 	introspectEndpoint,
@@ -11,92 +12,175 @@ import {
 	introspectSchemaFromUrl,
 } from "./helpers/introspection.js";
 import { getVersion } from "./helpers/package.js" with { type: "macro" };
+import { EndpointRegistry } from "./endpoints.js";
+import {
+	shouldWriteToFile,
+	writeOutputFile,
+	formatLargeJsonSummary,
+	formatLargeSchemaMessage,
+	summarizeJsonResult,
+} from "./response.js";
+import {
+	generateSchemaSummary,
+	generateTypeDetail,
+} from "./schema-summary.js";
+import { jsonToCsv } from "./csv.js";
 
 // Check for deprecated command line arguments
 checkDeprecatedArguments();
 
-const EnvSchema = z.object({
-	NAME: z.string().default("mcp-graphql"),
-	ENDPOINT: z.string().url().default("http://localhost:4000/graphql"),
-	ALLOW_MUTATIONS: z
-		.enum(["true", "false"])
-		.transform((value) => value === "true")
-		.default("false"),
-	HEADERS: z
-		.string()
-		.default("{}")
-		.transform((val) => {
-			try {
-				return JSON.parse(val);
-			} catch (e) {
-				throw new Error("HEADERS must be a valid JSON string");
-			}
-		}),
-	SCHEMA: z.string().optional(),
-});
+const config = loadConfig();
+const registry = new EndpointRegistry(config);
 
-const env = EnvSchema.parse(process.env);
+const endpointNames = registry.names();
+const serverName =
+	endpointNames[0] === "default" ? "mcp-graphql" : endpointNames[0];
+const serverDescription =
+	endpointNames.length === 1
+		? `GraphQL MCP server for ${registry.getDefault().url}`
+		: `GraphQL MCP server for endpoints: ${endpointNames.join(", ")}`;
 
 const server = new McpServer({
-	name: env.NAME,
+	name: serverName,
 	version: getVersion(),
-	description: `GraphQL MCP server for ${env.ENDPOINT}`,
+	description: serverDescription,
 });
 
-server.resource("graphql-schema", new URL(env.ENDPOINT).href, async (uri) => {
-	try {
-		let schema: string;
-		if (env.SCHEMA) {
-			if (
-				env.SCHEMA.startsWith("http://") ||
-				env.SCHEMA.startsWith("https://")
-			) {
-				schema = await introspectSchemaFromUrl(env.SCHEMA);
-			} else {
-				schema = await introspectLocalSchema(env.SCHEMA);
-			}
-		} else {
-			schema = await introspectEndpoint(env.ENDPOINT, env.HEADERS);
+/**
+ * Helper to introspect schema for a given endpoint config.
+ */
+async function introspectSchemaForEndpoint(endpoint: {
+	url: string;
+	headers: Record<string, string>;
+	schema?: string;
+}): Promise<string> {
+	if (endpoint.schema) {
+		if (
+			endpoint.schema.startsWith("http://") ||
+			endpoint.schema.startsWith("https://")
+		) {
+			return introspectSchemaFromUrl(endpoint.schema);
 		}
-
-		return {
-			contents: [
-				{
-					uri: uri.href,
-					text: schema,
-				},
-			],
-		};
-	} catch (error) {
-		throw new Error(`Failed to get GraphQL schema: ${error}`);
+		return introspectLocalSchema(endpoint.schema);
 	}
-});
+	return introspectEndpoint(endpoint.url, endpoint.headers);
+}
+
+// Register resources: one per endpoint
+for (const ep of registry.list()) {
+	const resourceName =
+		endpointNames.length === 1
+			? "graphql-schema"
+			: `graphql-schema-${ep.name}`;
+
+	server.resource(resourceName, new URL(ep.url).href, async (uri) => {
+		try {
+			const schema = await introspectSchemaForEndpoint(ep);
+			return {
+				contents: [
+					{
+						uri: uri.href,
+						text: schema,
+					},
+				],
+			};
+		} catch (error) {
+			throw new Error(`Failed to get GraphQL schema: ${error}`);
+		}
+	});
+}
+
+const endpointParamDescription =
+	endpointNames.length === 1
+		? "Endpoint name (optional, only one endpoint configured)"
+		: `Endpoint name. Available: ${endpointNames.join(", ")}. Default: ${registry.getDefault().name}`;
 
 server.tool(
 	"introspect-schema",
-	"Introspect the GraphQL schema, use this tool before doing a query to get the schema information if you do not have it available as a resource already.",
+	`Introspect the GraphQL schema. Returns a compact summary by default to save context. Use detail='full' for complete SDL, or detail='types' with specific type names for detailed type info. Supports multiple endpoints.`,
 	{
 		// This is a workaround to help clients that can't handle an empty object as an argument
-		// They will often send undefined instead of an empty object which is not allowed by the schema
 		__ignore__: z
 			.boolean()
 			.default(false)
 			.describe("This does not do anything"),
+		endpoint: z
+			.string()
+			.optional()
+			.describe(endpointParamDescription),
+		detail: z
+			.enum(["summary", "full", "types"])
+			.default("summary")
+			.describe(
+				"Level of detail: 'summary' returns type/field counts and root fields, 'full' returns complete SDL (written to file if large), 'types' returns specific types in detail",
+			),
+		types: z
+			.array(z.string())
+			.optional()
+			.describe(
+				"When detail='types', list of type names to return in detail",
+			),
 	},
-	async () => {
+	async ({ endpoint: endpointName, detail, types: typeNames }) => {
 		try {
-			let schema: string;
-			if (env.SCHEMA) {
-				schema = await introspectLocalSchema(env.SCHEMA);
-			} else {
-				schema = await introspectEndpoint(env.ENDPOINT, env.HEADERS);
+			const ep = registry.resolve(endpointName);
+			const sdl = await introspectSchemaForEndpoint(ep);
+
+			// Always write full SDL to file for reference
+			const filePath = writeOutputFile(sdl, "graphql", config.outputDir);
+
+			if (detail === "summary") {
+				const summary = generateSchemaSummary(sdl, ep.name);
+				return {
+					content: [
+						{
+							type: "text",
+							text: `${summary}\n\nFull schema: ${filePath}`,
+						},
+					],
+				};
+			}
+
+			if (detail === "types") {
+				if (!typeNames || typeNames.length === 0) {
+					return {
+						isError: true,
+						content: [
+							{
+								type: "text",
+								text: "Please provide type names via the 'types' parameter when using detail='types'",
+							},
+						],
+					};
+				}
+				const typeDetail = generateTypeDetail(sdl, typeNames);
+				return {
+					content: [
+						{
+							type: "text",
+							text: `${typeDetail}\n\nFull schema: ${filePath}`,
+						},
+					],
+				};
+			}
+
+			// detail === "full"
+			if (shouldWriteToFile(sdl, config.responseSizeThreshold)) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: formatLargeSchemaMessage(sdl, filePath),
+						},
+					],
+				};
 			}
 
 			return {
 				content: [
 					{
 						type: "text",
-						text: schema,
+						text: sdl,
 					},
 				],
 			};
@@ -116,22 +200,61 @@ server.tool(
 
 server.tool(
 	"query-graphql",
-	"Query a GraphQL endpoint with the given query and variables",
+	`Query a GraphQL endpoint. Supports multiple endpoints, CSV export (output_format='csv'), and row limiting (max_rows). Large responses are automatically written to file with a summary returned.`,
 	{
 		query: z.string(),
 		variables: z.string().optional(),
+		endpoint: z
+			.string()
+			.optional()
+			.describe(endpointParamDescription),
+		output_format: z
+			.enum(["json", "csv"])
+			.default("json")
+			.describe(
+				"Output format: 'json' (default, inline or file if large) or 'csv' (always written to file for data analysis)",
+			),
+		max_rows: z
+			.number()
+			.int()
+			.positive()
+			.optional()
+			.describe(
+				"Maximum number of result rows to return. Exceeding rows are truncated with total count reported.",
+			),
 	},
-	async ({ query, variables }) => {
+	async ({
+		query,
+		variables,
+		endpoint: endpointName,
+		output_format,
+		max_rows,
+	}) => {
+		let ep;
+		try {
+			ep = registry.resolve(endpointName);
+		} catch (error) {
+			return {
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: `${error}`,
+					},
+				],
+			};
+		}
+
 		try {
 			const parsedQuery = parse(query);
 
-			// Check if the query is a mutation
 			const isMutation = parsedQuery.definitions.some(
 				(def) =>
-					def.kind === "OperationDefinition" && def.operation === "mutation",
+					def.kind === "OperationDefinition" &&
+					def.operation === "mutation",
 			);
 
-			if (isMutation && !env.ALLOW_MUTATIONS) {
+			if (isMutation && !ep.allowMutations) {
 				return {
 					isError: true,
 					content: [
@@ -155,11 +278,11 @@ server.tool(
 		}
 
 		try {
-			const response = await fetch(env.ENDPOINT, {
+			const response = await fetch(ep.url, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					...env.HEADERS,
+					...ep.headers,
 				},
 				body: JSON.stringify({
 					query,
@@ -169,7 +292,6 @@ server.tool(
 
 			if (!response.ok) {
 				const responseText = await response.text();
-
 				return {
 					isError: true,
 					content: [
@@ -184,7 +306,6 @@ server.tool(
 			const data = await response.json();
 
 			if (data.errors && data.errors.length > 0) {
-				// Contains GraphQL errors
 				return {
 					isError: true,
 					content: [
@@ -200,11 +321,100 @@ server.tool(
 				};
 			}
 
+			// Apply max_rows truncation
+			let truncatedInfo: string | null = null;
+			if (max_rows != null) {
+				const summary = summarizeJsonResult(data);
+				if (summary && summary.rowCount > max_rows) {
+					const totalCount = summary.rowCount;
+					data.data[summary.rootKey] = data.data[
+						summary.rootKey
+					].slice(0, max_rows);
+					truncatedInfo = `Showing ${max_rows} of ${totalCount} total rows (max_rows=${max_rows}).`;
+				}
+			}
+
+			// CSV export: always write to file
+			if (output_format === "csv") {
+				const summary = summarizeJsonResult(data);
+				if (!summary) {
+					return {
+						isError: true,
+						content: [
+							{
+								type: "text",
+								text: "Cannot export to CSV: result does not contain an array of objects.",
+							},
+						],
+					};
+				}
+
+				const csvContent = jsonToCsv(data.data[summary.rootKey]);
+				if (!csvContent) {
+					return {
+						isError: true,
+						content: [
+							{
+								type: "text",
+								text: "Cannot export to CSV: failed to convert result to CSV.",
+							},
+						],
+					};
+				}
+
+				const filePath = writeOutputFile(
+					csvContent,
+					"csv",
+					config.outputDir,
+				);
+				const msg = truncatedInfo
+					? `${truncatedInfo}\nCSV exported: ${summary.rowCount > max_rows! ? max_rows : summary.rowCount} rows x ${summary.fields.length} columns\nFile: ${filePath}`
+					: `CSV exported: ${summary.rowCount} rows x ${summary.fields.length} columns\nFile: ${filePath}`;
+
+				return {
+					content: [
+						{
+							type: "text",
+							text: msg,
+						},
+					],
+				};
+			}
+
+			// JSON output: check size threshold
+			const jsonContent = JSON.stringify(data, null, 2);
+
+			if (shouldWriteToFile(jsonContent, config.responseSizeThreshold)) {
+				const filePath = writeOutputFile(
+					jsonContent,
+					"json",
+					config.outputDir,
+				);
+				const summary = formatLargeJsonSummary(data, filePath);
+				const text = truncatedInfo
+					? `${truncatedInfo}\n\n${summary}`
+					: summary;
+
+				return {
+					content: [
+						{
+							type: "text",
+							text,
+						},
+					],
+				};
+			}
+
+			// Small response: return inline
+			const text = truncatedInfo
+				? `${truncatedInfo}\n\n${jsonContent}`
+				: jsonContent;
+
 			return {
 				content: [
 					{
 						type: "text",
-						text: JSON.stringify(data, null, 2),
+						text,
 					},
 				],
 			};
@@ -219,7 +429,7 @@ async function main() {
 	await server.connect(transport);
 
 	console.error(
-		`Started graphql mcp server ${env.NAME} for endpoint: ${env.ENDPOINT}`,
+		`Started graphql mcp server "${serverName}" for endpoint(s): ${endpointNames.join(", ")}`,
 	);
 }
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,0 +1,132 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+
+const DEFAULT_OUTPUT_DIR = "/tmp/mcp-graphql/";
+
+/**
+ * Resolve output directory from env, config, or default.
+ * MCP_GRAPHQL_OUTPUT_DIR env > config.outputDir > "/tmp/mcp-graphql/"
+ * Expands ~ to homedir.
+ */
+export function getOutputDir(configOutputDir?: string): string {
+  let dir = process.env.MCP_GRAPHQL_OUTPUT_DIR ?? configOutputDir ?? DEFAULT_OUTPUT_DIR;
+  if (dir.startsWith("~")) {
+    dir = join(homedir(), dir.slice(1));
+  }
+  return dir;
+}
+
+/**
+ * Write content to an output file and return the absolute path.
+ * Filename: mcp-graphql-{Date.now()}-{first8CharsOfSha256}.{ext}
+ */
+export function writeOutputFile(content: string, ext: string, configOutputDir?: string): string {
+  const dir = getOutputDir(configOutputDir);
+  mkdirSync(dir, { recursive: true });
+
+  const hash = createHash("sha256").update(content).digest("hex").slice(0, 8);
+  const filename = `mcp-graphql-${Date.now()}-${hash}.${ext}`;
+  const filePath = join(dir, filename);
+
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+/**
+ * Check if content exceeds the given byte threshold.
+ */
+export function shouldWriteToFile(content: string, threshold: number): boolean {
+  return Buffer.byteLength(content, "utf-8") > threshold;
+}
+
+/**
+ * Analyze a GraphQL JSON response to extract summary info.
+ * Walks data.data looking for the first array value.
+ * Returns null if no array is found.
+ */
+export function summarizeJsonResult(data: any): {
+  rootKey: string;
+  rowCount: number;
+  fields: string[];
+  preview: any[];
+} | null {
+  const root = data?.data;
+  if (root == null || typeof root !== "object") {
+    return null;
+  }
+
+  for (const key of Object.keys(root)) {
+    const value = root[key];
+    if (Array.isArray(value) && value.length > 0) {
+      const firstItem = value[0];
+      const fields = firstItem != null && typeof firstItem === "object"
+        ? Object.keys(firstItem)
+        : [];
+      return {
+        rootKey: key,
+        rowCount: value.length,
+        fields,
+        preview: value.slice(0, 3),
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Truncate a string value to maxLen, appending "..." if truncated.
+ */
+function truncateCell(value: any, maxLen: number = 50): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  const str = typeof value === "object" ? JSON.stringify(value) : String(value);
+  if (str.length > maxLen) {
+    return str.slice(0, maxLen) + "...";
+  }
+  return str;
+}
+
+/**
+ * Format a large JSON response as a markdown summary + file path.
+ */
+export function formatLargeJsonSummary(data: any, filePath: string): string {
+  const summary = summarizeJsonResult(data);
+  if (summary == null) {
+    return `Full result written to: ${filePath}`;
+  }
+
+  const { rootKey, rowCount, fields, preview } = summary;
+  const lines: string[] = [];
+
+  lines.push("## Query Result Summary");
+  lines.push(`**Root key**: ${rootKey} | **Rows**: ${rowCount} | **Fields**: ${fields.join(", ")}`);
+  lines.push("");
+
+  if (preview.length > 0 && fields.length > 0) {
+    lines.push(`### Preview (first ${preview.length} rows)`);
+    lines.push(`| ${fields.map((f) => truncateCell(f)).join(" | ")} |`);
+    lines.push(`|${fields.map(() => "---").join("|")}|`);
+    for (const row of preview) {
+      const cells = fields.map((f) => truncateCell(row?.[f]));
+      lines.push(`| ${cells.join(" | ")} |`);
+    }
+    lines.push("");
+  }
+
+  lines.push(`Full result written to: ${filePath}`);
+  return lines.join("\n");
+}
+
+/**
+ * Format a large schema response summary + file path.
+ * Simple version: byte count + line count + file path.
+ */
+export function formatLargeSchemaMessage(sdl: string, filePath: string): string {
+  const byteCount = Buffer.byteLength(sdl, "utf-8");
+  const lineCount = sdl.split("\n").length;
+  return `Schema (${byteCount} bytes, ~${lineCount} lines) written to: ${filePath}`;
+}

--- a/src/schema-summary.ts
+++ b/src/schema-summary.ts
@@ -1,0 +1,226 @@
+import {
+  buildSchema,
+  isObjectType,
+  isInputObjectType,
+  isEnumType,
+  isUnionType,
+  isInterfaceType,
+  isScalarType,
+  type GraphQLArgument,
+  type GraphQLField,
+  type GraphQLNamedType,
+  type GraphQLSchema,
+} from "graphql";
+
+const BUILT_IN_SCALARS = new Set(["String", "Int", "Float", "Boolean", "ID"]);
+
+function isUserType(type: GraphQLNamedType): boolean {
+  const name = type.name;
+  if (name.startsWith("__")) return false;
+  if (BUILT_IN_SCALARS.has(name)) return false;
+  return true;
+}
+
+function formatArgs(args: readonly GraphQLArgument[]): string {
+  if (args.length === 0) return "";
+  const parts = args.map((a) => `${a.name}: ${a.type.toString()}`);
+  return `(${parts.join(", ")})`;
+}
+
+function formatField(field: GraphQLField<unknown, unknown>): string {
+  const args = formatArgs(field.args);
+  const deprecation = field.deprecationReason
+    ? ` — ${field.deprecationReason}`
+    : "";
+  const isDeprecated = field.deprecationReason != null;
+  const prefix = isDeprecated ? "**[deprecated]** " : "";
+  return `${prefix}${field.name}${args}: ${field.type.toString()}${deprecation}`;
+}
+
+function getFieldsArray(
+  type: GraphQLNamedType,
+): GraphQLField<unknown, unknown>[] {
+  if (isObjectType(type) || isInterfaceType(type) || isInputObjectType(type)) {
+    return Object.values(type.getFields());
+  }
+  return [];
+}
+
+function formatRootTypeSection(
+  schema: GraphQLSchema,
+  typeName: string,
+  label: string,
+): string | null {
+  const type = schema.getType(typeName);
+  if (!type || !isObjectType(type)) return null;
+
+  const fields = Object.values(type.getFields());
+  if (fields.length === 0) return null;
+
+  const lines: string[] = [];
+  lines.push(`### ${label} (${fields.length} fields)`);
+  for (const field of fields) {
+    lines.push(`- ${formatField(field)}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Generate a compact summary of a GraphQL schema from SDL.
+ */
+export function generateSchemaSummary(
+  sdl: string,
+  endpointName?: string,
+): string {
+  let schema: GraphQLSchema;
+  try {
+    schema = buildSchema(sdl);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `**Error parsing schema**: ${message}`;
+  }
+
+  const typeMap = schema.getTypeMap();
+  const userTypes = Object.values(typeMap).filter(isUserType);
+
+  let totalFields = 0;
+  for (const type of userTypes) {
+    totalFields += getFieldsArray(type).length;
+  }
+
+  const heading = endpointName
+    ? `## Schema Summary for '${endpointName}'`
+    : "## Schema Summary";
+
+  const lines: string[] = [
+    heading,
+    `**Types**: ${userTypes.length} | **Fields**: ${totalFields}`,
+    "",
+  ];
+
+  // Root types
+  const queryTypeName = schema.getQueryType()?.name ?? "Query";
+  const mutationTypeName = schema.getMutationType()?.name ?? "Mutation";
+  const subscriptionTypeName =
+    schema.getSubscriptionType()?.name ?? "Subscription";
+
+  const querySection = formatRootTypeSection(schema, queryTypeName, "Query");
+  if (querySection) {
+    lines.push(querySection);
+    lines.push("");
+  }
+
+  const mutationSection = formatRootTypeSection(
+    schema,
+    mutationTypeName,
+    "Mutation",
+  );
+  if (mutationSection) {
+    lines.push(mutationSection);
+    lines.push("");
+  }
+
+  const subscriptionSection = formatRootTypeSection(
+    schema,
+    subscriptionTypeName,
+    "Subscription",
+  );
+  if (subscriptionSection) {
+    lines.push(subscriptionSection);
+    lines.push("");
+  }
+
+  // Object types sorted by field count (exclude root types)
+  const rootNames = new Set([
+    queryTypeName,
+    mutationTypeName,
+    subscriptionTypeName,
+  ]);
+  const objectTypes = userTypes
+    .filter((t) => isObjectType(t) && !rootNames.has(t.name))
+    .map((t) => ({
+      name: t.name,
+      fieldCount: getFieldsArray(t).length,
+    }))
+    .sort((a, b) => b.fieldCount - a.fieldCount);
+
+  if (objectTypes.length > 0) {
+    lines.push("### Object Types (sorted by field count)");
+    for (const t of objectTypes) {
+      lines.push(`- ${t.name} (${t.fieldCount} fields)`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+/**
+ * Generate detailed info for specific type names.
+ */
+export function generateTypeDetail(sdl: string, typeNames: string[]): string {
+  let schema: GraphQLSchema;
+  try {
+    schema = buildSchema(sdl);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `**Error parsing schema**: ${message}`;
+  }
+
+  const sections: string[] = [];
+
+  for (const name of typeNames) {
+    const type = schema.getType(name);
+    if (!type) {
+      sections.push(`## Type: ${name}\n_Type not found_`);
+      continue;
+    }
+
+    const lines: string[] = [`## Type: ${name}`];
+
+    if (isObjectType(type) || isInterfaceType(type) || isInputObjectType(type)) {
+      const fields = Object.values(type.getFields());
+      for (const field of fields) {
+        lines.push(`- ${formatField(field)}`);
+      }
+    } else if (isEnumType(type)) {
+      for (const val of type.getValues()) {
+        const dep = val.deprecationReason != null
+          ? ` **[deprecated]** — ${val.deprecationReason}`
+          : "";
+        lines.push(`- ${val.name}${dep}`);
+      }
+    } else if (isUnionType(type)) {
+      const members = type.getTypes().map((t) => t.name);
+      lines.push(`Union of: ${members.join(" | ")}`);
+    } else if (isScalarType(type)) {
+      lines.push(`_Custom scalar_`);
+    }
+
+    sections.push(lines.join("\n"));
+  }
+
+  return sections.join("\n\n").trimEnd();
+}
+
+/**
+ * Count user-defined types (exclude built-in scalars and __* introspection types).
+ */
+export function countUserTypes(sdl: string): { types: number; fields: number } {
+  let schema: GraphQLSchema;
+  try {
+    schema = buildSchema(sdl);
+  } catch {
+    return { types: 0, fields: 0 };
+  }
+
+  const typeMap = schema.getTypeMap();
+  const userTypes = Object.values(typeMap).filter(isUserType);
+
+  let fields = 0;
+  for (const type of userTypes) {
+    fields += getFieldsArray(type).length;
+  }
+
+  return { types: userTypes.length, fields };
+}


### PR DESCRIPTION
## Summary

Adds multi-endpoint support and LLM context optimization to mcp-graphql.

- **Multi-endpoint**: single instance serves multiple GraphQL APIs via JSON config file, backward compatible with env vars
- **Schema summary**: `introspect-schema` defaults to compact markdown (type/field counts, root fields) instead of full SDL; `detail` param for full/types modes
- **Response offloading**: responses exceeding configurable threshold written to file, summary + path returned inline
- **CSV export**: `output_format=csv` writes query results as CSV to file
- **Pagination**: `max_rows` param for application-level result truncation

No new runtime dependencies. Backward compatible — existing single-endpoint env var config works unchanged.

## Test plan

Self-tested against multiple live GraphQL endpoints (schema introspection, queries, CSV export, pagination, error handling). Build and type check pass clean.